### PR TITLE
CC-815355: BRP - Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/library/src/main/java/com/getchute/android/photopickerplus/util/PhotoPickerPreferenceUtil.java
+++ b/library/src/main/java/com/getchute/android/photopickerplus/util/PhotoPickerPreferenceUtil.java
@@ -51,7 +51,7 @@ public class PhotoPickerPreferenceUtil {
 		this.context = context;
 	}
 
-	static PhotoPickerPreferenceUtil instance;
+	static volatile PhotoPickerPreferenceUtil instance;
 
 	public static PhotoPickerPreferenceUtil get() {
 		return instance;
@@ -62,10 +62,13 @@ public class PhotoPickerPreferenceUtil {
 	}
 
 	public static void init(Context context) {
-		if (instance == null) {
-			instance = new PhotoPickerPreferenceUtil(
-					context.getApplicationContext());
-		}
+		        if (instance == null) {
+                        synchronized (PhotoPickerPreferenceUtil.class) {
+                                if (instance == null) {
+                                        instance = new PhotoPickerPreferenceUtil(context.getApplicationContext());
+                                }
+                        }
+                }
 	}
 
 	public SharedPreferences getPreferences() {


### PR DESCRIPTION
https://jira.devfactory.com/browse/CC-815355